### PR TITLE
chore: fix typo `availabile` -> `available`

### DIFF
--- a/pages/trading/prelaunch-markets.mdx
+++ b/pages/trading/prelaunch-markets.mdx
@@ -1,6 +1,6 @@
 # Prelaunch Market
 
-Prelaunch Markets are custom markets that allow users to book trade before reliable external oracle is availabile.
+Prelaunch Markets are custom markets that allow users to book trade before reliable external oracle is available.
 
 Instead of relying on an external oracle for liquidations, funding, and margin calculation, they utilize a [custom oracle source](/trading/market-specs#prelaunch) that current mark TWAP (with window = the funding period).
 


### PR DESCRIPTION
Likely a docs-wide automated check of grammar and typographies would be better