### PR TITLE
fix discord invite link

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -38,7 +38,7 @@ We achieved that by setting up sophisticated **cross-margined risk engine** - a 
 - [**Tutorials**](/tutorial-bots/keeper-bots) - Build a [**Keeper bot**](/tutorial-bots/keeper-bots) or [**JIT Trading bot**](/tutorial-bots/trading-bots/tutorial-jit-trading-bot).
 - [**Drift Gateway**](https://github.com/drift-labs/gateway) - Self hosted API gateway to easily interact with Drift V2 Protocol
 
-Drift Protocol is [**open-source**](https://github.com/drift-labs/protocol-v2) and contributions are welcome. Our support is available at all times on [**Discord**](https://discord.gg/driftprotocol).
+Drift Protocol is [**open-source**](https://github.com/drift-labs/protocol-v2) and contributions are welcome. Our support is available at all times on [**Discord**](https://discord.com/invite/fMcZBH8ErM).
 
 [**Build a bot.**](/tutorial-bots/keeper-bots)
 


### PR DESCRIPTION
current link is broken.
I pulled the valid link from https://www.drift.trade/